### PR TITLE
Change tip to callout

### DIFF
--- a/src/main/scala/com/gu/targeting/client/Fields.scala
+++ b/src/main/scala/com/gu/targeting/client/Fields.scala
@@ -25,7 +25,7 @@ object Fields {
   val epicType = "epic"
   val reportType = "report"
   val surveyType = "survey"
-  val participationType = "tip"
+  val participationType = "callout"
 
   val allTypes = List(emailType, badgeType, epicType, reportType, surveyType, participationType)
 


### PR DESCRIPTION
As we rename "tip" to "callout" in the frontend app, we need to make this change here too. To keep things consistent. 