### PR TITLE
Add optional Contacts to calloutCampaign ParticipationFields

### DIFF
--- a/src/main/scala/com/gu/targeting/client/Fields.scala
+++ b/src/main/scala/com/gu/targeting/client/Fields.scala
@@ -10,7 +10,7 @@ case class BadgeFields(seriesTag: String, imageUrl: String, classModifier: Optio
 case class EpicFields(campaignId: String) extends Fields
 case class ReportFields(campaignId: String) extends Fields
 case class SurveyFields(campaignId: String, questions: Seq[SurveyQuestion]) extends Fields
-case class ParticipationFields(callout: String, formId: Int, tagName: String, description: Option[String], prompt: Option[String], formFields: JsValue, formUrl: Option[String], contacts: Option[Seq[Contact]]) extends Fields
+case class ParticipationFields(callout: String, formId: Int, tagName: String, description: Option[String], formFields: JsValue, formUrl: Option[String], contacts: Option[Seq[Contact]]) extends Fields
 
 case class Contact(name: String, value: String)
 case class SurveyQuestion(question: String, askWhy: Boolean)

--- a/src/test/scala/com/gu/targeting/client/CampaignTest.scala
+++ b/src/test/scala/com/gu/targeting/client/CampaignTest.scala
@@ -21,7 +21,7 @@ class CampaignTests extends AnyFreeSpec with Matchers {
 
   "Campaign should convert participation campaigns to JSON correctly" in {
     val contactFields = Some(Seq(Contact("Whatsapp", "1245"), Contact("Signal", "0000")))
-    val fields = ParticipationFields("testCallout", 1245, "test-callout-tag", Some("testDescription"), Some("testPrompt"), JsArray(Seq(JsString("one"), JsBoolean(false), JsString("three"))), Some("https://some.url/withAPath"), contactFields)
+    val fields = ParticipationFields("testCallout", 1245, "test-callout-tag", Some("testDescription"), JsArray(Seq(JsString("one"), JsBoolean(false), JsString("three"))), Some("https://some.url/withAPath"), contactFields)
     val campaign = Campaign(id, "name", rules, 10, None, None, false, fields)
     Campaign.fromJson(Json.toJson(campaign)) should equal(campaign)
   }


### PR DESCRIPTION
## What does this change?

This PR adds an optional array of contacts to the ParticipationFields in the Callout Campaign. This will be used to determine which contact us buttons to show in the callout UI, and also allows editorial to override the contact number.