### PR TITLE
Add 2 new fields to the callout campaign contacts field

### DIFF
--- a/src/main/scala/com/gu/targeting/client/Fields.scala
+++ b/src/main/scala/com/gu/targeting/client/Fields.scala
@@ -12,7 +12,7 @@ case class ReportFields(campaignId: String) extends Fields
 case class SurveyFields(campaignId: String, questions: Seq[SurveyQuestion]) extends Fields
 case class ParticipationFields(callout: String, formId: Int, tagName: String, description: Option[String], formFields: JsValue, formUrl: Option[String], contacts: Option[Seq[Contact]]) extends Fields
 
-case class Contact(name: String, value: String)
+case class Contact(name: String, value: String, urlPrefix: String, guidance: Option[String])
 case class SurveyQuestion(question: String, askWhy: Boolean)
 
 // Add more fields here as applicable

--- a/src/test/scala/com/gu/targeting/client/CampaignTest.scala
+++ b/src/test/scala/com/gu/targeting/client/CampaignTest.scala
@@ -20,7 +20,9 @@ class CampaignTests extends AnyFreeSpec with Matchers {
   }
 
   "Campaign should convert participation campaigns to JSON correctly" in {
-    val contactFields = Some(Seq(Contact("Whatsapp", "1245"), Contact("Signal", "0000")))
+    val contactFields = Some(Seq(
+      Contact("Whatsapp", "1245", "https://wa.me/", Some("https://www.theguardian.com/info/2015/aug/12/whatsapp-sharing-stories-with-the-guardian")),
+      Contact("Signal", "0000", "https://signal.me/#p/", None)))
     val fields = ParticipationFields("testCallout", 1245, "test-callout-tag", Some("testDescription"), JsArray(Seq(JsString("one"), JsBoolean(false), JsString("three"))), Some("https://some.url/withAPath"), contactFields)
     val campaign = Campaign(id, "name", rules, 10, None, None, false, fields)
     Campaign.fromJson(Json.toJson(campaign)) should equal(campaign)


### PR DESCRIPTION
## What does this change?
This updates the recently added contacts field in a callout campaign to add 2 new fields, a `urlPrefix` string, and a `guidance` optional string. These will not be surfaced to the user in targeting-tool, but we're adding them now to make it easier to add more supported types of contacts in the future.

