### PR TITLE
Update `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,6 @@ Versions
   libraryDependencies += "com.gu.targeting-client" %% "client-play-json-v28" % "[maven version number]"
   ```
 
-# Usage
-
-To use this library add the following to your dependency libraries in your projects `build.sbt`:
-
-`"com.gu" %% "targeting-client" % "1.1.0"`
-
-Instead of version `0.1.0` insert the version you'd like to use (probably the latest). 
-
-
 # Adding a new Campaign Type
 
 Campaign types are expressed as a set of fields. To add a new set of fields edit the Fields.scala file in the following way. I'll use the example set of a charity drive campaign.
@@ -40,6 +31,8 @@ Campaign types are expressed as a set of fields. To add a new set of fields edit
 
 > \* Note: you cannot have a variable called `_type` since the JSON serializers use this string in order to know what type of field is being read.
 
-# Publishing a new version
+# Publishing a new release
 
-This repo is using the [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) library. Detailed instructions for how to release a new version can be found [here](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md).
+This repo uses [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow)
+to automate publishing releases (both full & preview releases) - see
+[**Making a Release**](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md).

--- a/README.md
+++ b/README.md
@@ -2,13 +2,27 @@
 
 This repository contains shared code used by targeting, frontend, and MAPI to create and process targeted campaigns.
 
-# Version mapping
+Versions
+--------
 
-|Targeting Client Version|Play Version|Scala Version     |Artefact                                            |
-|------------------------|------------|------------------|----------------------------------------------------|
-|0.14.8                  |2.6         |2.11 & 2.12       |`"com.gu" %% "targeting-client-play26" % "0.14.8"`  |
-|1.0.x                   |2.7         |2.11 & 2.12 & 2.13|`"com.gu" %% "targeting-client" % "1.0.0"`          |
-|1.1.x                   |2.8         |2.12 & 2.13       |`"com.gu" %% "targeting-client" % "1.1.0"`          |
+### Supported Play Versions
+
+* Play **3.0** : use [![targeting-client artifacts](https://index.scala-lang.org/guardian/grid/targeting-client/client-play-json-v30/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/grid/targeting-client/client-play-json-v28/)
+  ```
+  libraryDependencies += "com.gu.targeting-client" %% "client-play-json-v30" % "[maven version number]"
+  ```
+* Play **2.8** : use [![targeting-client artifacts](https://index.scala-lang.org/guardian/grid/targeting-client/client-play-json-v28/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/grid/targeting-client/client-play-json-v28/)
+  ```
+  libraryDependencies += "com.gu.targeting-client" %% "client-play-json-v28" % "[maven version number]"
+  ```
+* Play **2.7** : use [![targeting-client artifacts](https://img.shields.io/badge/targeting--client_--_JVM-1.0.0_(Scala_2.13,_2.12,_2.11)-green.svg)](https://index.scala-lang.org/guardian/grid/targeting-client)
+  ```
+  libraryDependencies += "com.gu" %% "targeting-client" % "[maven version number]"
+  ```
+* Play **2.6** : use [![targeting-client artifacts](https://index.scala-lang.org/guardian/grid/targeting-client-play26/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/grid/targeting-client-play26)
+  ```
+  libraryDependencies += "com.gu" %% "targeting-client" % "[maven version number]"
+  ```
 
 # Usage
 
@@ -36,5 +50,4 @@ Campaign types are expressed as a set of fields. To add a new set of fields edit
 
 # Publishing a new version
 
-1. Get access to oss.sonatype.org (ask a Dev Manager/team member if unsure on this - there is a []doc on this](https://docs.google.com/document/d/1M_MiE8qntdDn97QIRnIUci5wdVQ8_defCqpeAwoKY8g/edit#heading=h.7n25tzj28wmr))
-2. Run `sbt release`
+This repo is using the [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) library. Detailed instructions for how to release a new version can be found [here](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md).

--- a/README.md
+++ b/README.md
@@ -15,14 +15,6 @@ Versions
   ```
   libraryDependencies += "com.gu.targeting-client" %% "client-play-json-v28" % "[maven version number]"
   ```
-* Play **2.7** : use [![targeting-client artifacts](https://img.shields.io/badge/targeting--client_--_JVM-1.0.0_(Scala_2.13,_2.12,_2.11)-green.svg)](https://index.scala-lang.org/guardian/grid/targeting-client)
-  ```
-  libraryDependencies += "com.gu" %% "targeting-client" % "[maven version number]"
-  ```
-* Play **2.6** : use [![targeting-client artifacts](https://index.scala-lang.org/guardian/grid/targeting-client-play26/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/grid/targeting-client-play26)
-  ```
-  libraryDependencies += "com.gu" %% "targeting-client" % "[maven version number]"
-  ```
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Versions
   ```
   libraryDependencies += "com.gu.targeting-client" %% "client-play-json-v30" % "[maven version number]"
   ```
-* Play **2.8** : use [![targeting-client artifacts](https://index.scala-lang.org/guardian/grid/targeting-client/client-play-json-v28/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/grid/targeting-client/client-play-json-v28/)
+* Play **2.8** : use [![client-play-json-v28 Scala version support](https://index.scala-lang.org/guardian/targeting-client/client-play-json-v28/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/guardian/targeting-client/client-play-json-v28)
   ```
   libraryDependencies += "com.gu.targeting-client" %% "client-play-json-v28" % "[maven version number]"
   ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Versions
 
 ### Supported Play Versions
 
-* Play **3.0** : use [![targeting-client artifacts](https://index.scala-lang.org/guardian/grid/targeting-client/client-play-json-v30/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/grid/targeting-client/client-play-json-v28/)
+* Play **3.0** : use [![client-play-json-v30 Scala version support](https://index.scala-lang.org/guardian/targeting-client/client-play-json-v30/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/guardian/targeting-client/client-play-json-v30)
   ```
   libraryDependencies += "com.gu.targeting-client" %% "client-play-json-v30" % "[maven version number]"
   ```


### PR DESCRIPTION
## What does this change?

After:

* https://github.com/guardian/targeting-client/pull/37 

`targeting-client` supports multiple Play versions concurrently. PR #37 also changed the group id and added a `release.yml` file. The new workflow performs releases using the [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) library. This PR updates the `README` to reflect these changes.
