### PR TITLE
Temporarily remove line that checks previous version in `build.sbt`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,6 @@ lazy val root = (project in file(".")).aggregate(
 
 val sonatypeReleaseSettings = Seq(
   licenses := Seq("Apache V2" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
-  releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value,
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
     inquireVersions,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The first release failed https://github.com/guardian/targeting-client/actions/runs/7299624335/job/19892813494 because in https://github.com/guardian/targeting-client/pull/37 we changed the Maven coordinates of the artifact so now `sbt-version-policy` plugin cannot find the previous version. Once we perform a release we will put back this line. See also https://github.com/guardian/facia-scala-client/pull/300#issuecomment-1862510888

