### PR TITLE
Add release version check back

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ lazy val root = (project in file(".")).aggregate(
 )
 
 val sonatypeReleaseSettings = Seq(
+  releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value,
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
     inquireVersions,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds release version check back. It was removed in:
* https://github.com/guardian/targeting-client/pull/40 

because in https://github.com/guardian/targeting-client/pull/37 we changed the Maven coordinates of the artifact so sbt-version-policy plugin could not find the previous version. We now have a [successful release](https://github.com/guardian/targeting-client/actions/runs/7756318559) so we can add this check back.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

