### PR TITLE
Add shortText field for apple news

### DIFF
--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/Fields.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/Fields.scala
@@ -18,11 +18,11 @@ case class ReporterCalloutFields(title: String,
                                  intro: String,
                                  mainTextHeading: String,
                                  mainText: String,
+                                 shortText: String, // for apple news/other platforms where we cant collapse the component
                                  emailContact: Option[String],
                                  messagingContact: Option[String],
                                  securedropContact: Option[String],
-                                 endNote: Option[String],
-                                 shortText: Option[String] // for apple news/other platforms where we cant collapse the component
+                                 endNote: Option[String]
                                  ) extends Fields
 
 case class Contact(name: String, value: String, urlPrefix: String, guidance: Option[String])

--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/Fields.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/Fields.scala
@@ -21,7 +21,8 @@ case class ReporterCalloutFields(title: String,
                                  emailContact: Option[String],
                                  messagingContact: Option[String],
                                  securedropContact: Option[String],
-                                 endNote: Option[String]
+                                 endNote: Option[String],
+                                 shortText: Option[String] // for apple news/other platforms where we cant collapse the component
                                  ) extends Fields
 
 case class Contact(name: String, value: String, urlPrefix: String, guidance: Option[String])


### PR DESCRIPTION
## What does this change?
Apple news doesn't support having expandable/collapsible components, so we need a special field in reporter callouts for apple news. This PR adds such a field

## How to test
I've tested this using targeting CODE here https://github.com/guardian/targeting/pull/215