### PR TITLE
Add Apple News component types

### DIFF
--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
@@ -22,7 +22,7 @@ case class ANComponent(
 )
 
 // ANComponent type without the id field to allow parsing before creating the component and assigning the ID
-case class PreCreateANComponent(
+case class ANComponentWithoutID(
   name: String,
   active: Boolean,
   regions: ANRegions,
@@ -32,6 +32,10 @@ case class PreCreateANComponent(
 
 object ANComponent {
   implicit val format: Format[ANComponent] = Json.format[ANComponent]
+}
+
+object ANComponentWithoutID {
+  implicit val format: Format[ANComponentWithoutID] = Json.format[ANComponentWithoutID]
 }
 
 sealed trait ComponentData

--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
@@ -11,7 +11,7 @@ case class ANComponent(
   name: String,
   active: Boolean,
   regions: ANRegions,
-  rules: List[Rule],
+  rules: Seq[Rule],
   data: ComponentData
 )
 
@@ -20,7 +20,7 @@ case class ANComponentWithoutID(
   name: String,
   active: Boolean,
   regions: ANRegions,
-  rules: List[Rule],
+  rules: Seq[Rule],
   data: ComponentData
 )
 

--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
@@ -21,6 +21,15 @@ case class ANComponent(
   data: ComponentData
 )
 
+// ANComponent type without the id field to allow parsing before creating the component and assigning the ID
+case class preCreateANComponent(
+  name: String,
+  active: Boolean,
+  regions: ANRegions,
+  rules: List[Rule],
+  data: ComponentData
+)
+
 object ANComponent {
   implicit val format: Format[ANComponent] = Json.format[ANComponent]
 }

--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
@@ -22,7 +22,7 @@ case class ANComponent(
 )
 
 // ANComponent type without the id field to allow parsing before creating the component and assigning the ID
-case class preCreateANComponent(
+case class PreCreateANComponent(
   name: String,
   active: Boolean,
   regions: ANRegions,

--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
@@ -12,22 +12,29 @@ import scala.io.Source
 import scala.util.Try
 
 // AN stands for Apple News
-sealed trait ANComponent {
-  val id: UUID
-  val name: String
-  val active: Boolean
-  val regions: ANRegions
-  val rules: List[Rule]
-}
+case class ANComponent(
+  id: UUID,
+  name: String,
+  active: Boolean,
+  regions: ANRegions,
+  rules: List[Rule],
+  data: ComponentData
+)
 
 object ANComponent {
-  implicit val reads: Reads[ANComponent] = (JsPath \ "type")
+  implicit val format: Format[ANComponent] = Json.format[ANComponent]
+}
+
+sealed trait ComponentData
+
+object ComponentData {
+  implicit val reads: Reads[ComponentData] = (JsPath \ "type")
     .read[String]
     .flatMap(_ match {
       case "podcast" => Json.reads[Podcast].widen
-      case t         => Reads.failed(s"Unrecognised ANComponent type: $t")
+      case t         => Reads.failed(s"Unrecognised ComponentData type: $t")
     })
-  implicit val writes: Writes[ANComponent] =
+  implicit val writes: Writes[ComponentData] =
     Writes(_ match {
       case p: Podcast =>
         (Json
@@ -37,13 +44,8 @@ object ANComponent {
 }
 
 case class Podcast(
-  id: UUID,
-  name: String,
-  active: Boolean,
   podcastLink: URI,
-  regions: ANRegions,
-  rules: List[Rule]
-) extends ANComponent
+) extends ComponentData
 
 object Podcast {
   implicit val format: Format[Podcast] = Json.format[Podcast]
@@ -58,10 +60,9 @@ object ANRegions {
 case class ANComponentCache(appleNewsComponents: List[ANComponent], totalANComponents: Option[Int]) {
   def getANComponentsForTags(tags: Seq[String], stripRules: Boolean = false): List[ANComponent] = {
       appleNewsComponents.filter(c => c.rules.exists(r => Rule.evaluate(r, tags))).map { c =>
-        if (stripRules) c match {
-          case p: Podcast => p.copy(rules = Nil)
-          case other => other
-        }  else c
+        if (stripRules) c.data match {
+          case p: Podcast => c.copy(rules = Nil)
+        } else c
       }
   }
 }

--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
@@ -4,12 +4,6 @@ import java.net.URI
 import java.util.UUID
 
 import play.api.libs.json._
-import org.apache.http.client.methods.HttpGet
-import org.apache.http.impl.client.HttpClients
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.io.Source
-import scala.util.Try
 
 // AN stands for Apple News
 case class ANComponent(
@@ -68,53 +62,4 @@ case class ANRegions(US: Boolean, UK: Boolean, AU: Boolean)
 
 object ANRegions {
   implicit val format: Format[ANRegions] = Json.format[ANRegions]
-}
-
-case class ANComponentCache(appleNewsComponents: List[ANComponent], totalANComponents: Option[Int]) {
-  def getANComponentsForTags(tags: Seq[String], stripRules: Boolean = false): List[ANComponent] = {
-      appleNewsComponents.filter(c => c.rules.exists(r => Rule.evaluate(r, tags))).map { c =>
-        if (stripRules) c.data match {
-          case p: Podcast => c.copy(rules = Nil)
-        } else c
-      }
-  }
-}
-
-object ANComponentCache {
-  val TOTAL_COMPONENTS_HEADER_NAME = "Total-AN-Components"
-
-  /** Fetch a new Apple News Components cache which contains the latest components.
-   * @param url should correspond to the api end point which lists components as json (https://targeting.gutools.co.uk/api/apple-news)
-   * @param limit truncate the number of components to this number
-   * @param ruleLimit Any components with more rules than this number will be dropped from the results
-   * @param tagLimit Any components with any rules with more tags (requiredTags + lackingTags) than this number will be dropped
-   * @param ec The execution context that will execute the blocking HTTP request
-   */
-  def fetch(url: String, limit: Int = 100, ruleLimit: Option[Int] = None, tagLimit: Option[Int] = None)(implicit ec: ExecutionContext): Future[ANComponentCache] = {
-    val queryUrl = url + s"?activeOnly=true&limit=$limit&types=${Fields.allTypes.mkString(",")}"
-
-    Future {
-      val response = HttpClients.createDefault().execute(new HttpGet(queryUrl))
-
-      val status = response.getStatusLine.getStatusCode
-      if (!(200 to 299).contains(status)) {
-        throw TargetingServiceException(s"Failed to get Apple News component list, status code: $status")
-      }
-
-      val body = Source.fromInputStream(response.getEntity.getContent).getLines().mkString("")
-
-      // Total number of components, used to indicate to the client how many components they've truncated
-      val header = response.getFirstHeader(TOTAL_COMPONENTS_HEADER_NAME)
-      val totalANComponents = Try(header.getValue.toInt).toOption
-
-      val appleNewsComponents = Json.parse(body).as[List[ANComponent]].filter(appleNewsComponent => {
-        // Is the number of rules less than or equal to the limit?
-        ruleLimit.forall(appleNewsComponent.rules.length <= _) &&
-        // And all of the rules have too many required or lacking tags
-        tagLimit.forall(limit => appleNewsComponent.rules.forall(rule => rule.requiredTags.length + rule.lackingTags.length <= limit))
-      })
-
-      ANComponentCache(appleNewsComponents, totalANComponents)
-    }
-  }
 }

--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/AppleNewsItem.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/AppleNewsItem.scala
@@ -1,0 +1,43 @@
+package com.gu.targeting.client
+
+import java.net.URI
+import java.util.UUID
+
+import play.api.libs.json._
+
+sealed trait AppleNewsItem
+
+object AppleNewsItem {
+  implicit val reads: Reads[AppleNewsItem] = (JsPath \ "type")
+    .read[String]
+    .flatMap(_ match {
+      case "podcast" => Json.reads[Podcast].widen
+      case t         => Reads.failed(s"Unrecognised AppleNewsItem type: $t")
+    })
+  implicit val writes: Writes[AppleNewsItem] =
+    Writes(_ match {
+      case p: Podcast =>
+        (Json
+          .obj("type" -> JsString("podcast"))
+          ++ Json.writes[Podcast].writes(p))
+    })
+}
+
+case class Podcast(
+  id: UUID,
+  name: String,
+  active: Boolean,
+  podcastLink: URI,
+  regions: AppleNewsRegions,
+  rules: List[Rule]
+) extends AppleNewsItem
+
+object Podcast {
+  implicit val format: Format[Podcast] = Json.format[Podcast]
+}
+
+case class AppleNewsRegions(US: Boolean, UK: Boolean, AU: Boolean)
+
+object AppleNewsRegions {
+  implicit val format: Format[AppleNewsRegions] = Json.format[AppleNewsRegions]
+}

--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/AppleNewsItem.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/AppleNewsItem.scala
@@ -11,22 +11,23 @@ import scala.concurrent.Future
 import scala.io.Source
 import scala.util.Try
 
-sealed trait AppleNewsItem {
+// AN stands for Apple News
+sealed trait ANComponent {
   val id: UUID
   val name: String
   val active: Boolean
-  val regions: AppleNewsRegions
+  val regions: ANRegions
   val rules: List[Rule]
 }
 
-object AppleNewsItem {
-  implicit val reads: Reads[AppleNewsItem] = (JsPath \ "type")
+object ANComponent {
+  implicit val reads: Reads[ANComponent] = (JsPath \ "type")
     .read[String]
     .flatMap(_ match {
       case "podcast" => Json.reads[Podcast].widen
-      case t         => Reads.failed(s"Unrecognised AppleNewsItem type: $t")
+      case t         => Reads.failed(s"Unrecognised ANComponent type: $t")
     })
-  implicit val writes: Writes[AppleNewsItem] =
+  implicit val writes: Writes[ANComponent] =
     Writes(_ match {
       case p: Podcast =>
         (Json
@@ -40,23 +41,23 @@ case class Podcast(
   name: String,
   active: Boolean,
   podcastLink: URI,
-  regions: AppleNewsRegions,
+  regions: ANRegions,
   rules: List[Rule]
-) extends AppleNewsItem
+) extends ANComponent
 
 object Podcast {
   implicit val format: Format[Podcast] = Json.format[Podcast]
 }
 
-case class AppleNewsRegions(US: Boolean, UK: Boolean, AU: Boolean)
+case class ANRegions(US: Boolean, UK: Boolean, AU: Boolean)
 
-object AppleNewsRegions {
-  implicit val format: Format[AppleNewsRegions] = Json.format[AppleNewsRegions]
+object ANRegions {
+  implicit val format: Format[ANRegions] = Json.format[ANRegions]
 }
 
-case class AppleNewsItemCache(appleNewsItems: List[AppleNewsItem], totalAppleNewsItems: Option[Int]) {
-  def getAppleNewsItemsForTags(tags: Seq[String], stripRules: Boolean = false): List[AppleNewsItem] = {
-      appleNewsItems.filter(c => c.rules.exists(r => Rule.evaluate(r, tags))).map { c =>
+case class ANComponentCache(appleNewsComponents: List[ANComponent], totalANComponents: Option[Int]) {
+  def getANComponentsForTags(tags: Seq[String], stripRules: Boolean = false): List[ANComponent] = {
+      appleNewsComponents.filter(c => c.rules.exists(r => Rule.evaluate(r, tags))).map { c =>
         if (stripRules) c match {
           case p: Podcast => p.copy(rules = Nil)
           case other => other
@@ -65,17 +66,17 @@ case class AppleNewsItemCache(appleNewsItems: List[AppleNewsItem], totalAppleNew
   }
 }
 
-object AppleNewsItemCache {
-  val TOTAL_ITEMS_HEADER_NAME = "Total-Apple-News-Items"
+object ANComponentCache {
+  val TOTAL_COMPONENTS_HEADER_NAME = "Total-AN-Components"
 
-  /** Fetch a new Apple News Items cache which contains the latest items.
-   * @param url should correspond to the api end point which lists items as json (https://targeting.gutools.co.uk/api/apple-news)
-   * @param limit truncate the number of items to this number
-   * @param ruleLimit Any items with more rules than this number will be dropped from the results
-   * @param tagLimit Any items with any rules with more tags (requiredTags + lackingTags) than this number will be dropped
+  /** Fetch a new Apple News Components cache which contains the latest components.
+   * @param url should correspond to the api end point which lists components as json (https://targeting.gutools.co.uk/api/apple-news)
+   * @param limit truncate the number of components to this number
+   * @param ruleLimit Any components with more rules than this number will be dropped from the results
+   * @param tagLimit Any components with any rules with more tags (requiredTags + lackingTags) than this number will be dropped
    * @param ec The execution context that will execute the blocking HTTP request
    */
-  def fetch(url: String, limit: Int = 100, ruleLimit: Option[Int] = None, tagLimit: Option[Int] = None)(implicit ec: ExecutionContext): Future[AppleNewsItemCache] = {
+  def fetch(url: String, limit: Int = 100, ruleLimit: Option[Int] = None, tagLimit: Option[Int] = None)(implicit ec: ExecutionContext): Future[ANComponentCache] = {
     val queryUrl = url + s"?activeOnly=true&limit=$limit&types=${Fields.allTypes.mkString(",")}"
 
     Future {
@@ -83,23 +84,23 @@ object AppleNewsItemCache {
 
       val status = response.getStatusLine.getStatusCode
       if (!(200 to 299).contains(status)) {
-        throw TargetingServiceException(s"Failed to get Apple News item list, status code: $status")
+        throw TargetingServiceException(s"Failed to get Apple News component list, status code: $status")
       }
 
       val body = Source.fromInputStream(response.getEntity.getContent).getLines().mkString("")
 
-      // Total number of items, used to indicate to the client how many items they've truncated
-      val header = response.getFirstHeader(TOTAL_ITEMS_HEADER_NAME)
-      val totalAppleNewsItems = Try(header.getValue.toInt).toOption
+      // Total number of components, used to indicate to the client how many components they've truncated
+      val header = response.getFirstHeader(TOTAL_COMPONENTS_HEADER_NAME)
+      val totalANComponents = Try(header.getValue.toInt).toOption
 
-      val appleNewsItems = Json.parse(body).as[List[AppleNewsItem]].filter(appleNewsItem => {
+      val appleNewsComponents = Json.parse(body).as[List[ANComponent]].filter(appleNewsComponent => {
         // Is the number of rules less than or equal to the limit?
-        ruleLimit.forall(appleNewsItem.rules.length <= _) &&
+        ruleLimit.forall(appleNewsComponent.rules.length <= _) &&
         // And all of the rules have too many required or lacking tags
-        tagLimit.forall(limit => appleNewsItem.rules.forall(rule => rule.requiredTags.length + rule.lackingTags.length <= limit))
+        tagLimit.forall(limit => appleNewsComponent.rules.forall(rule => rule.requiredTags.length + rule.lackingTags.length <= limit))
       })
 
-      AppleNewsItemCache(appleNewsItems, totalAppleNewsItems)
+      ANComponentCache(appleNewsComponents, totalANComponents)
     }
   }
 }

--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/AppleNewsItem.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/AppleNewsItem.scala
@@ -4,6 +4,12 @@ import java.net.URI
 import java.util.UUID
 
 import play.api.libs.json._
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.impl.client.HttpClients
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.io.Source
+import scala.util.Try
 
 sealed trait AppleNewsItem
 
@@ -40,4 +46,53 @@ case class AppleNewsRegions(US: Boolean, UK: Boolean, AU: Boolean)
 
 object AppleNewsRegions {
   implicit val format: Format[AppleNewsRegions] = Json.format[AppleNewsRegions]
+}
+
+case class AppleNewsItemCache(appleNewsItems: List[AppleNewsItem], totalAppleNewsItems: Option[Int]) {
+  def getAppleNewsItemsForTags(tags: Seq[String], stripRules: Boolean = false): List[AppleNewsItem] = {
+    // TODO :need to conditionalise this for podcasts properly
+      appleNewsItem.filter(c => c.rules.exists(r => Rule.evaluate(r, tags))).map { c =>
+        if (stripRules) c.copy(rules = Nil) else c
+      }
+  }
+}
+
+object AppleNewsItemCache {
+  val TOTAL_ITEMS_HEADER_NAME = "Total-Apple-News-Items"
+
+  /** Fetch a new Apple News Items cache which contains the latest items.
+   * @param url should correspond to the api end point which lists items as json (https://targeting.gutools.co.uk/api/apple-news)
+   * @param limit truncate the number of items to this number
+   * @param ruleLimit Any items with more rules than this number will be dropped from the results
+   * @param tagLimit Any items with any rules with more tags (requiredTags + lackingTags) than this number will be dropped
+   * @param ec The execution context that will execute the blocking HTTP request
+   */
+  def fetch(url: String, limit: Int = 100, ruleLimit: Option[Int] = None, tagLimit: Option[Int] = None)(implicit ec: ExecutionContext): Future[AppleNewsItemCache] = {
+    val queryUrl = url + s"?activeOnly=true&limit=$limit&types=${Fields.allTypes.mkString(",")}"
+
+    Future {
+      val response = HttpClients.createDefault().execute(new HttpGet(queryUrl))
+
+      val status = response.getStatusLine.getStatusCode
+      if (!(200 to 299).contains(status)) {
+        throw TargetingServiceException(s"Failed to get Apple News item list, status code: $status")
+      }
+
+      val body = Source.fromInputStream(response.getEntity.getContent).getLines().mkString("")
+
+      // Total number of items, used to indicate to the client how many items they've truncated
+      val header = response.getFirstHeader(TOTAL_ITEMS_HEADER_NAME)
+      val totalAppleNewsItems = Try(header.getValue.toInt).toOption
+
+      val appleNewsItems = Json.parse(body).as[List[AppleNewsItem]].filter(appleNewsItem => {
+        // TODO: handle types here
+        // Is the number of rules less than or equal to the limit?
+        ruleLimit.forall(appleNewsItem.rules.length <= _) &&
+        // And all of the rules have too many required or lacking tags
+        tagLimit.forall(limit => appleNewsItem.rules.forall(rule => rule.requiredTags.length + rule.lackingTags.length <= limit))
+      })
+
+      AppleNewsItemCache(appleNewsItems, totalAppleNewsItems)
+    }
+  }
 }

--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/AppleNewsItem.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/AppleNewsItem.scala
@@ -11,7 +11,13 @@ import scala.concurrent.Future
 import scala.io.Source
 import scala.util.Try
 
-sealed trait AppleNewsItem
+sealed trait AppleNewsItem {
+  val id: UUID
+  val name: String
+  val active: Boolean
+  val regions: AppleNewsRegions
+  val rules: List[Rule]
+}
 
 object AppleNewsItem {
   implicit val reads: Reads[AppleNewsItem] = (JsPath \ "type")
@@ -50,9 +56,11 @@ object AppleNewsRegions {
 
 case class AppleNewsItemCache(appleNewsItems: List[AppleNewsItem], totalAppleNewsItems: Option[Int]) {
   def getAppleNewsItemsForTags(tags: Seq[String], stripRules: Boolean = false): List[AppleNewsItem] = {
-    // TODO :need to conditionalise this for podcasts properly
-      appleNewsItem.filter(c => c.rules.exists(r => Rule.evaluate(r, tags))).map { c =>
-        if (stripRules) c.copy(rules = Nil) else c
+      appleNewsItems.filter(c => c.rules.exists(r => Rule.evaluate(r, tags))).map { c =>
+        if (stripRules) c match {
+          case p: Podcast => p.copy(rules = Nil)
+          case other => other
+        }  else c
       }
   }
 }
@@ -85,7 +93,6 @@ object AppleNewsItemCache {
       val totalAppleNewsItems = Try(header.getValue.toInt).toOption
 
       val appleNewsItems = Json.parse(body).as[List[AppleNewsItem]].filter(appleNewsItem => {
-        // TODO: handle types here
         // Is the number of rules less than or equal to the limit?
         ruleLimit.forall(appleNewsItem.rules.length <= _) &&
         // And all of the rules have too many required or lacking tags


### PR DESCRIPTION
## What does this change?
Adds new types for Apple News Components and Podcasts for use in the `targeting` repo. Adds an `ANComponent` type that includes an ID field. This is for when a component has been created and an ID has been assigned. Also adds an `ANComponentWithoutID` type. This is so we can parse in json for a new Apple News component before it has been created and assigned an ID.

## How has this change been tested?
A preview version has been released and tested in `targeting`.
