### PR TITLE
Clarify Rule evaluation

### DIFF
--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/Rule.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/Rule.scala
@@ -13,8 +13,7 @@ object Rule {
     )(Rule.apply, unlift(Rule.unapply))
 
   def evaluate(rule: Rule, tags: Seq[String]): Boolean = {
-    if (rule.matchAllTags) tags.intersect(rule.lackingTags).isEmpty
-    else tags.intersect(rule.requiredTags).nonEmpty && tags.intersect(rule.lackingTags).isEmpty
+    (rule.matchAllTags || tags.intersect(rule.requiredTags).nonEmpty) && tags.intersect(rule.lackingTags).isEmpty
   }
 
 }

--- a/client-play-json-v28/src/test/scala/com/gu/targeting/client/RuleTest.scala
+++ b/client-play-json-v28/src/test/scala/com/gu/targeting/client/RuleTest.scala
@@ -9,7 +9,7 @@ class RuleTest extends AnyFreeSpec with Matchers {
 
   val rule = Rule(tagsToMatch, tagsToExclude, false)
 
-  "A rule" - {
+  "A rule with required and excluded tags" - {
     "when evaluated" - {
       "returns true with matching tags" in {
         assert(Rule.evaluate(rule, tagsToMatch))
@@ -31,6 +31,31 @@ class RuleTest extends AnyFreeSpec with Matchers {
         assert(!Rule.evaluate(rule, List(tagsToMatch(0), tagsToExclude(0))))
       }
 
+    }
+  }
+
+  val lackingOnlyRule = Rule(List.empty, tagsToExclude, false)
+
+  "A rule with only lacking tags" - {
+    "will never match anything" in {
+      assert(!Rule.evaluate(lackingOnlyRule, tagsToMatch))
+      assert(!Rule.evaluate(lackingOnlyRule, List.empty))
+    }
+  }
+
+  val matchAllRule = Rule(List.empty, tagsToExclude, true)
+
+  "A rule with matchAllTags set" - {
+    "will match things with arbitrary tags" in {
+      assert(Rule.evaluate(matchAllRule, tagsToMatch))
+    }
+
+    "will match things with no tags" in {
+      assert(Rule.evaluate(matchAllRule, List.empty))
+    }
+
+    "won’t match things with its excluded tags" in {
+      assert(!Rule.evaluate(matchAllRule, tagsToMatch ++ tagsToExclude))
     }
   }
 }


### PR DESCRIPTION
## What does this change?

I think using boolean operators here is a clearer implementation of the logic: “for a rule to match, either matchAllTags has to be set or one of the tags has to be in requiredTags, and none of lackingTags can be present”.

I’m confident the refactor produces the same behaviour because if rule.matchAllTags is true, then “rule.matchAllTags || A” is equivalent to A for any A.

## How has this change been tested?

I added some unit tests in https://github.com/guardian/targeting-client/pull/54/commits/d37a80be4cc5348cbd633540a49ad209830c4961, and can see that they passed before and after the refactor.