### PR TITLE
Add PodcastOrientation to Podcast class

### DIFF
--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
@@ -57,26 +57,24 @@ object ComponentData {
 
 case class Podcast(
   podcastLink: URI,
-  orientation: PodcastOrientation
+  orientation: Podcast.Orientation
 ) extends ComponentData
 
-sealed trait PodcastOrientation
-object PodcastOrientation {
-  implicit val reads: Reads[PodcastOrientation] = Reads.StringReads.flatMap {
-    case "automatic"  => Reads.pure(Automatic)
-    case "horizontal" => Reads.pure(Horizontal)
-    case s            => Reads.failed(s"Unrecognised PodcastOrientation value: $s")
-  }
-  implicit val writes: Writes[PodcastOrientation] = Writes.StringWrites.contramap {
-    case Automatic  => "automatic"
-    case Horizontal => "horizontal"
-  }
-}
-
-case object Automatic extends PodcastOrientation
-case object Horizontal extends PodcastOrientation
-
 object Podcast {
+  sealed trait Orientation {
+    val name: String
+  }
+  object Orientation {
+    case object Automatic extends Orientation { val name: String = "automatic" }
+    case object Horizontal extends Orientation { val name: String = "horizontal" }
+    val All: Seq[Orientation] = Seq(Automatic, Horizontal)
+
+    implicit val reads: Reads[Orientation] = Reads.StringReads.flatMap { s: String =>
+      All.find(_.name == s).fold(Reads.failed[Orientation](s"Unrecognised Orientation value: $s"))(Reads.pure(_))
+    }
+    implicit val writes: Writes[Orientation] = Writes.StringWrites.contramap(_.name)
+  }
+
   implicit val format: Format[Podcast] = Json.format[Podcast]
 }
 

--- a/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
+++ b/client-play-json-v28/src/main/scala/com/gu/targeting/client/ANComponent.scala
@@ -57,7 +57,24 @@ object ComponentData {
 
 case class Podcast(
   podcastLink: URI,
+  orientation: PodcastOrientation
 ) extends ComponentData
+
+sealed trait PodcastOrientation
+object PodcastOrientation {
+  implicit val reads: Reads[PodcastOrientation] = Reads.StringReads.flatMap {
+    case "automatic"  => Reads.pure(Automatic)
+    case "horizontal" => Reads.pure(Horizontal)
+    case s            => Reads.failed(s"Unrecognised PodcastOrientation value: $s")
+  }
+  implicit val writes: Writes[PodcastOrientation] = Writes.StringWrites.contramap {
+    case Automatic  => "automatic"
+    case Horizontal => "horizontal"
+  }
+}
+
+case object Automatic extends PodcastOrientation
+case object Horizontal extends PodcastOrientation
 
 object Podcast {
   implicit val format: Format[Podcast] = Json.format[Podcast]

--- a/client-play-json-v28/src/test/scala/com/gu/targeting/client/ANComponentTest.scala
+++ b/client-play-json-v28/src/test/scala/com/gu/targeting/client/ANComponentTest.scala
@@ -9,7 +9,7 @@ import play.api.libs.json.Json
 class ANComponentTest extends AnyFreeSpec with Matchers {
   private val podcastData = Podcast(
     podcastLink = new java.net.URI("https://www.theguardian.com/podcasts/series/today-in-focus"),
-    orientation = Horizontal
+    orientation = Podcast.Orientation.Horizontal
   )
 
   private val newsletterSignupData = NewsletterSignup(

--- a/client-play-json-v28/src/test/scala/com/gu/targeting/client/ANComponentTest.scala
+++ b/client-play-json-v28/src/test/scala/com/gu/targeting/client/ANComponentTest.scala
@@ -9,6 +9,7 @@ import play.api.libs.json.Json
 class ANComponentTest extends AnyFreeSpec with Matchers {
   private val podcastData = Podcast(
     podcastLink = new java.net.URI("https://www.theguardian.com/podcasts/series/today-in-focus"),
+    orientation = Horizontal
   )
 
   private val newsletterSignupData = NewsletterSignup(
@@ -49,7 +50,8 @@ class ANComponentTest extends AnyFreeSpec with Matchers {
         "rules": [],
         "data": {
           "type": "podcast",
-          "podcastLink": "https://www.theguardian.com/podcasts/series/today-in-focus"
+          "podcastLink": "https://www.theguardian.com/podcasts/series/today-in-focus",
+          "orientation": "horizontal"
         }
       }
       """)


### PR DESCRIPTION
## What does this change?
Adds a definition for PodcastOrientation to the Podcast type. Uses the definition that currently lives in apple-news. This will allow us to define display orientation in targeting, instead of hard coding an override in Apple News.

## How has this change been tested?
Have tested locally using the preview release.

